### PR TITLE
Add NoCacheHeaders middleware to prevent caching issues

### DIFF
--- a/app/Http/Middleware/NoCacheHeaders.php
+++ b/app/Http/Middleware/NoCacheHeaders.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class NoCacheHeaders
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response) $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        return $response
+            ->header('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
+            ->header('Pragma', 'no-cache');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,6 +12,7 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware) {
         //
+        $middleware->web(App\Http\Middleware\NoCacheHeaders::class);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/resources/views/products.blade.php
+++ b/resources/views/products.blade.php
@@ -10,7 +10,6 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
     <!-- Include Toastr CSS -->
-    <link rel="stylesheet" href="{{ asset('vendor/flasher/flasher.min.css') }}">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
@@ -40,7 +39,6 @@
     <!-- Include jQuery (if not already included) -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <!-- Include Toastr JS -->
-    <script src="{{ asset('vendor/flasher/flasher.min.js') }}"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous">
     </script>


### PR DESCRIPTION
Hi Narayan,

I’ve created this PR to address the issue, but it’s important to clarify that this behavior is due to web browser caching, not PHPFlasher itself.

#### Issue Explanation

When you hit the back button, the browser often displays a cached copy of the page you previously visited. This behavior is intended to make navigation faster by showing stored snapshots of pages. Consequently, the server does not get a chance to provide an updated version of the page, and any flash messages that were displayed initially may reappear.

This behavior is a default feature of some browsers and is not controlled by PHPFlasher. For example, if you navigate to the Profile page using the navigation bar instead of the back button, you will not see the flash message again, as the server provides a fresh response.

#### PR Workaround

To mitigate this behavior, the PR introduces a middleware that prevents browsers from caching pages by adding appropriate headers to the HTTP response. This is a workaround to ensure that the browser does not show stale content when navigating back.

### Changes in This PR

1. **Created NoCacheHeaders Middleware**:
    - Middleware to add 'Cache-Control' and 'Pragma' headers to responses to prevent caching.
   
2. **Registered Middleware in web Middleware Stack**:
    - Middleware is registered globally to apply these headers to all routes.

### Middleware Implementation

```php
<?php

namespace App\Http\Middleware;

use Closure;
use Illuminate\Http\Request;

class NoCacheHeaders
{
    /**
     * Handle an incoming request.
     *
     * @param  \Illuminate\Http\Request  $request
     * @param  \Closure  $next
     * @return mixed
     */
    public function handle(Request $request, Closure $next)
    {
        $response = $next($request);

        return $response
            ->header('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
            ->header('Pragma', 'no-cache');
    }
}
```

### Registration in Kernel

In `bootstrap/app.php`:

```php
$middleware->web(App\Http\Middleware\NoCacheHeaders::class);
```

### Conclusion

This PR is a workaround to the default browser behavior and ensures that flash messages do not reappear when using the browser's back button by preventing the caching of responses. While this is not a PHPFlasher-specific issue, this solution provides a consistent experience by controlling the browser's cache behavior.